### PR TITLE
Throw BoundsError for invalid indices

### DIFF
--- a/src/ImmutableArrays.jl
+++ b/src/ImmutableArrays.jl
@@ -45,7 +45,7 @@ for n = 2:4
     @eval zero{T}(::Type{$TypT}) = $TypT(zero(T))
 
     # define getindex
-    local getix = :(return zero(T))
+    local getix = :(error(BoundsError))
     for i = n:-1:1
         en = Expr(:quote,symbol(string("e",i)))
         getix = :(if ix == $i return v.($en) else $getix end)

--- a/test/core.jl
+++ b/test/core.jl
@@ -5,6 +5,14 @@ typealias Vec3d Vector3{Float64}
 v1 = Vec3d(1.0,2.0,3.0)
 v2 = Vec3d(6.0,5.0,4.0)
 
+# indexing
+@assert v1[1] == 1.0
+@assert v1[2] == 2.0
+@assert v1[3] == 3.0
+@assert try v1[-1]; false; catch e; isa(e,BoundsError); end
+@assert try v1[0];  false; catch e; isa(e,BoundsError); end
+@assert try v1[4];  false; catch e; isa(e,BoundsError); end
+
 # addition
 @assert v1+v2 == Vec3d(7.0,7.0,7.0)
 


### PR DESCRIPTION
Throw `BoundsError` for invalid indices. This makes behavior consistent with native Julia arrays.
