### PR TITLE
Cross product

### DIFF
--- a/src/ImmutableArrays.jl
+++ b/src/ImmutableArrays.jl
@@ -132,4 +132,7 @@ for n = 2:4
     @eval norm{T}(v::$TypT) = sqrt(dot(v,v))
 end
 
+cross(a::Vector3,b::Vector3) =
+    Vector3(a.e2*b.e3-a.e3*b.e2, a.e3*b.e1-a.e1*b.e3, a.e1*b.e2-a.e2*b.e1)
+
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -60,3 +60,7 @@ v2 = Vec3d(6.0,5.0,4.0)
 
 # vector norm
 @assert norm(Vec3d(1.0,2.0,2.0)) == 3.0
+
+# cross product
+@assert cross(v1,v2) == Vec3d(-7.0,14.0,-7.0)
+@assert isa(cross(v1,v2),Vec3d)


### PR DESCRIPTION
Before: `cross(Vector3, Vector3)` returned an `Array`
After: `cross(Vector3, Vector3)` returns a `Vector3`

Outer constructors were added to `VectorN` so that an appropriately-typed version of `VectorN` is created based on the type of the constructor arguments:

`VectorN(a::T)` returns a `VectorN{T}`

This allows functionality to match native Julia:

`cross(Array{Int8,1}, Array{Float32,1})` returns an `Array{Float32,1}`
`cross(Vector3{Int8}, Vector3{Float32})` returns a `Vector3{Float32}`
