### PR TITLE
Add (naive) type conversion

### DIFF
--- a/src/generate_arrays.jl
+++ b/src/generate_arrays.jl
@@ -176,6 +176,7 @@ function generateArrays(maxSz::Integer)
         @eval diagm{T}(v::$TypT) = $bdy
 
         # some one-liners
+        @eval convert{T}(::Type{$TypT}, V::$Typ) = $TypT(ntuple($sz, x->V[x])...)
         @eval similar{T}(::$TypT, t::DataType, dims::Dims) = Array(t, dims)
         @eval size(::$Typ) = ($sz,)
         @eval zero{T}(::Type{$TypT}) = $TypT(zero(T))

--- a/test/core.jl
+++ b/test/core.jl
@@ -3,6 +3,7 @@ using ImmutableArrays
 typealias Vec2d Vector2{Float64}
 typealias Vec3d Vector3{Float64}
 typealias Vec4d Vector4{Float64}
+typealias Vec3f Vector3{Float32}
 
 v1 = Vec3d(1.0,2.0,3.0)
 v2 = Vec3d(6.0,5.0,4.0)
@@ -76,6 +77,9 @@ e4 = unit(Vec4d,4)
 @assert e2 == Vec4d(0.0,1.0,0.0,0.0)
 @assert e3 == Vec4d(0.0,0.0,1.0,0.0)
 @assert e4 == Vec4d(0.0,0.0,0.0,1.0)
+
+# type conversion
+@assert isa(convert(Vec3f,v1),Vec3f)
 
 # matrix operations
 typealias Mat4d Matrix4x4{Float64}


### PR DESCRIPTION
Something like `convert(::Type{Vector3{Float32}}, ::Vector3{Float64})` is now possible (just like native Julia arrays).

The implementation is naive and uses `ntuple`. The performance is actually quite bad! I'm guessing it can be improved with `mapBody` somehow, but I was having trouble figuring it out.

This is basically the last bit of functionality needed for me to completely switch over to ImmutableArrays from my homebrew implementation :grinning:
