### PR TITLE
Put inline annotation on getindex for immutable arrays

### DIFF
--- a/src/generate_arrays.jl
+++ b/src/generate_arrays.jl
@@ -104,7 +104,7 @@ function generate_arrays(maxSz::Integer)
             local val = mem(:v,elt(i))
             getix = :(ix == $i ? $val : $getix)
         end
-        getix = :(getindex{T}(v::$TypT, ix::Integer) = $getix)
+        getix = :(@inline getindex{T}(v::$TypT, ix::Integer) = $getix)
         eval(getix)
 
         # helper for defining maps


### PR DESCRIPTION
The inline heuristic did not trigger for this function and I have seen
significant speedup for code that depends on this with this change.